### PR TITLE
[Podspec] Set platform to 7.0

### DIFF
--- a/FBMemoryProfiler.podspec
+++ b/FBMemoryProfiler.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.homepage     = "https://github.com/facebook/FBMemoryProfiler"
   s.license      = "BSD"
   s.author       = { "Grzegorz Pstrucha" => "gricha@fb.com" }
-  s.platform     = :ios, "8.0"
+  s.platform     = :ios, "7.0"
   s.source       = {
     :git => "https://github.com/facebook/FBMemoryProfiler.git",
     :tag => "0.1.1"


### PR DESCRIPTION
# Description
This pull request allows projects with a deployment target of iOS 7.0 to integrate FBMemoryProfiler.

# Note
The podspecs of FBMemoryProfilers dependencies have to be changed as well:
https://github.com/facebook/FBAllocationTracker/pull/5
https://github.com/facebook/FBRetainCycleDetector/pull/5