### PR TITLE
Fix crashes for missing classNames

### DIFF
--- a/FBMemoryProfiler/Controllers/FBMemoryProfilerDataSource.m
+++ b/FBMemoryProfiler/Controllers/FBMemoryProfilerDataSource.m
@@ -182,7 +182,7 @@ static UIColor *FBMemoryProfilerPaleRedColor() {
       return NO;
     }
 
-    if (entry.aliveObjects > 0) {
+    if (entry.aliveObjects > 0 && entry.className) {
       return YES;
     }
 


### PR DESCRIPTION
This fixes crashes, in case the className is nil for some reason.

If I have time, I will try to find out, why the className can be nil in the first place :)