### PR TITLE
Only invoke `memoryProfilerDidFindRetainCycles:` delegate methods if count > 0

### DIFF
--- a/FBMemoryProfiler/Controllers/FBMemoryProfilerViewController.m
+++ b/FBMemoryProfiler/Controllers/FBMemoryProfilerViewController.m
@@ -274,9 +274,12 @@ retainCycleDetectorConfiguration:(FBObjectGraphConfiguration *)retainCycleDetect
       NSSet<NSArray<FBObjectiveCGraphElement *> *> *retainCycles =
       [detector findRetainCyclesWithMaxCycleLength:8];
 
-      for (id<FBMemoryProfilerPluggable> plugin in _profilerOptions.plugins) {
-        if ([plugin respondsToSelector:@selector(memoryProfilerDidFindRetainCycles:)]) {
-          [plugin memoryProfilerDidFindRetainCycles:retainCycles];
+      // only tell plugins if we really found something
+      if ([retainCycles count] > 0) {
+        for (id<FBMemoryProfilerPluggable> plugin in _profilerOptions.plugins) {
+          if ([plugin respondsToSelector:@selector(memoryProfilerDidFindRetainCycles:)]) {
+            [plugin memoryProfilerDidFindRetainCycles:retainCycles];
+          }
         }
       }
 


### PR DESCRIPTION
Only invoke method when found retain cycle count > 0. Previously it was also invoked when count == 0.