### PR TITLE
Fix crash when repo's description is empty.

### DIFF
--- a/Example/ExampleApp/GithubRepository.m
+++ b/Example/ExampleApp/GithubRepository.m
@@ -16,7 +16,7 @@
 {
   if (self = [super init]) {
     _name = [name copy];
-    _shortDescription = [shortDescription copy];
+    _shortDescription = ([shortDescription class] != [NSNull class]) ? [shortDescription copy] : @"No Description";
     _url = [url copy];
   }
   


### PR DESCRIPTION
The JSON objects  from the request of [https://api.github.com/orgs/facebook/repos?per_page=300](https://api.github.com/orgs/facebook/repos?per_page=300 ) may conatin null value, like the repo [https://github.com/facebook/caf8teen]( https://github.com/facebook/caf8teen), there is no repo description, when you create `GithubRepository` object, the shortDescription's value is `[NSNull null]`. When you want to show the repos list, it will crash when executing `cell.detailTextLabel.text = _data[indexPath.row].shortDescription;`.

In the example, we only use three values, repo's name, description, html_url, the name and url must be valid, only the description my has nothing.

Environment: Xcode 8.1 beta2, Simulator iPhone 7 Plus